### PR TITLE
fix: use bg-dark from rl ui spec

### DIFF
--- a/static/css/default.css
+++ b/static/css/default.css
@@ -13,7 +13,7 @@ body {
 }
 
 /* Try to mesh with green logo image */
-.navbar-dark { background-color: #1c2421; color: #fff; }
+.navbar-dark { background-color: #18181b; color: #fff; }
 
 .row { margin-left: 0 }
 


### PR DESCRIPTION
The colour used in the navbar is wrong, as seen in our design specs. Needs to be #18181b -- this PR corrects that